### PR TITLE
Bandaid to get project running

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ This is a modification and enhancement of the existing WebPlotDigitizer by Ankit
 
 # Building and Running
 
+## August 2022 update:
+** Project currently needs to be run with node v10.17.0 until build process changes are made.
+
+Changes needed:
+1. Gulp implementation needs to be updated for v4 compatibility.
+2. Update node to current LTS version
+**
+
 * npm install
 * npm run build
 * npm run start

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "rollup": "^0.34.7",
     "source-map-support": "^0.4.2",
     "spectron": "^3.3.0",
-    "yargs": "^4.2.0"
+    "yargs": "^4.2.0",
+    "natives": "^1.1.6"
   }
 }


### PR DESCRIPTION
Temporary fix to run project. Tested with node v10.17.0

1. Gulp implementation needs to be updated for v4 compatibility
2. then update to current Node version